### PR TITLE
Refactor DynamicScaler with validation and ignore_scalers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.3.0
+- Refatoração do `DynamicScaler` com validação pós-transform.
+- Suporte a `ignore_scalers` e lista de fallback curta.
+- Novo parâmetro `validation_fraction` e função de `scoring` customizável.
+- Atualização da documentação.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Selecione e aplique dinamicamente o scaler mais adequado para cada feature numé
   - `auto`: decide o scaler por coluna usando critérios estatísticos.  
   - `standard`, `robust`, `minmax`, `quantile`: aplica o mesmo scaler a todas as colunas.  
   - `passthrough`: não aplica escalonamento.  
-- **Compatível com `scikit-learn` Pipelines**, facilitando integração em fluxos de trabalho.  
-- **Serialização** automática de scalers e relatórios em arquivo `.pkl` (`save` / `load`).  
+- **Compatível com `scikit-learn` Pipelines**, facilitando integração em fluxos de trabalho.
+- **Serialização** automática de scalers e relatórios em arquivo `.pkl` (`save` / `load`).
 - **Relatórios** via DataFrame (`report_as_df`) e **visualizações** de histogramas antes/depois (`plot_histograms`).
+- **Validação rápida** com amostra holdout e fallback entre scalers.
+- **`ignore_scalers`** para pular transformadores indesejados.
 
 ---
 

--- a/tests/test_dynamic_scaler.py
+++ b/tests/test_dynamic_scaler.py
@@ -5,6 +5,7 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from scaler import DynamicScaler
 from sklearn.exceptions import NotFittedError
+import numpy as np
 
 
 def test_transform_preserves_extra_columns():
@@ -38,3 +39,35 @@ def test_ignore_cols_no_scaling():
     transformed = scaler.transform(df, return_df=True)
     pd.testing.assert_series_equal(transformed['b'], df['b'])
     assert 'b' not in scaler.scalers_
+
+
+def test_collapse_rejected():
+    np.random.seed(42)
+    x = np.concatenate([np.random.normal(0, 1, 95), np.random.normal(10, 1, 5)])
+    df = pd.DataFrame({'a': x})
+    scaler = DynamicScaler(min_post_std=1.5, scoring=lambda _, arr: arr.std(), random_state=42)
+    scaler.fit(df)
+    assert scaler.report_['a']['chosen_scaler'] == 'RobustScaler'
+
+
+def test_ignore_scalers():
+    df = pd.DataFrame({'a': [1, 2, 3, 4, 5]})
+    scaler = DynamicScaler(ignore_scalers=['PowerTransformer'], scoring=lambda _, arr: arr.std())
+    scaler.fit(df)
+    assert scaler.report_['a']['candidates_tried'][0] == 'QuantileTransformer'
+
+
+def test_all_rejected():
+    df = pd.DataFrame({'a': [1, 2, 3, 4]})
+    scaler = DynamicScaler(min_post_std=100, scoring=lambda _, arr: arr.std())
+    scaler.fit(df)
+    assert scaler.report_['a']['chosen_scaler'] == 'None'
+    assert scaler.report_['a']['reason'] == 'all_rejected'
+
+
+def test_scoring_improves():
+    np.random.seed(0)
+    df = pd.DataFrame({'a': np.exp(np.random.normal(size=100))})
+    scaler = DynamicScaler(random_state=0)
+    scaler.fit(df)
+    assert scaler.report_['a']['chosen_scaler'] == 'PowerTransformer'


### PR DESCRIPTION
## Summary
- add validation flow with ignore_scalers and short fallback list
- add version bump and changelog
- enhance README with new features
- add extensive tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce3913dc88321afb21faae57f3e7c