### PR TITLE
Populate reason field for accepted scalers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+- Campo `reason` populado para scalers aceitos com flags de validação.
+- Tabela de colunas do report atualizada.
+
 ## 0.5.0
 - Validação de importância via SHAP/gain substitui ganho de CV.
 - Novos parâmetros `importance_metric` e `importance_gain_thr`.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ flowchart TD
 | `plot_histograms(orig, trans, features, show_qq=False)` | Visualiza distribuições antes/depois. |
 | `save(path)` / `load(path)` | Serializa e restaura scalers + relatório + metadados. |
 
+## 📝 Colunas do report
+
+| Coluna | Descrição |
+|--------|-----------|
+| `chosen_scaler` | Nome do scaler aprovado ou `None`. |
+| `validation_stats` | Métricas pós-transformação. |
+| `ignored` | Lista de scalers ignorados. |
+| `candidates_tried` | Candidatos testados. |
+| `reason` | Pipe-separated flags explicando por que o scaler foi aceito (ex. stats|skew|kurt|imp). |
+
 ---
 
 ## ⚙️ Parâmetros Importantes

--- a/scaler.py
+++ b/scaler.py
@@ -26,7 +26,7 @@ from sklearn.preprocessing import (
     PowerTransformer,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 
 class DynamicScaler(BaseEstimator, TransformerMixin):
@@ -262,6 +262,16 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
                 "ignored": list(self.ignore_scalers),
                 "candidates_tried": tried,
             }
+            reason_parts = ["stats"]
+            if abs(skew_test) < abs(baseline_score):
+                reason_parts.append("skew")
+            if abs(kurt_test) < abs(baseline_kurt) and abs(kurt_test) <= self.kurtosis_thr:
+                reason_parts.append("kurt")
+            if normal:
+                reason_parts.append("normal")
+            if need_imp:
+                reason_parts.append("imp")
+            report["reason"] = "|".join(reason_parts)
             if stats_callback:
                 stats_callback(x.name, report)
             return scaler, report

--- a/tests/test_reason_field.py
+++ b/tests/test_reason_field.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from scaler import DynamicScaler
+
+
+def test_reason_present():
+    df = pd.read_csv("data/case_data_science_credit.csv", sep=";")
+    df_num = df.select_dtypes("number").drop(columns=["client_id", "target"])
+    y = df["target"]
+    ds = DynamicScaler(strategy="auto", importance_metric="gain").fit(df_num, y)
+    rpt = ds.report_as_df()
+    assert rpt["reason"].notna().all()
+    assert rpt.loc["saldo_rotativo_total", "reason"].startswith("stats")
+


### PR DESCRIPTION
## Summary
- bump version to 0.5.1
- build `reason` strings for accepted scalers
- document new `reason` column in README
- add changelog entry for 0.5.1
- add test verifying `reason` is always populated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0ad0f9948321a9f5555db7dfbc2f